### PR TITLE
Add server params

### DIFF
--- a/launch/grasp_generator_server.launch
+++ b/launch/grasp_generator_server.launch
@@ -2,8 +2,14 @@
 
   <arg name="robot" default="reem" />
 
+  <arg name="group"        default="right_arm" />
+  <arg name="end_effector" default="right" />
+
   <!-- Start the test -->
   <node name="moveit_simple_grasps_server" pkg="moveit_simple_grasps" type="moveit_simple_grasps_server" output="screen">
+    <param name="group"        value="$(arg group)"/>
+    <param name="end_effector" value="$(arg end_effector)"/>
+
     <rosparam command="load" file="$(find moveit_simple_grasps)/config/$(arg robot)_grasp_data.yaml"/>
   </node>
 

--- a/src/simple_grasps_server.cpp
+++ b/src/simple_grasps_server.cpp
@@ -33,9 +33,9 @@
  */
 
 /* Author: Bence Magyar
-   Desc:   Action server wrapper for object grasp generator. Currently only works for REEM robot, 
-           needs to be changed to work with yaml configuration file instead.
-*/
+ *         Enrique Fernandez
+ * Desc:   Action server wrapper for object grasp generator.
+ */
 
 // ROS
 #include <ros/ros.h>
@@ -125,21 +125,24 @@ namespace moveit_simple_grasps
     moveit_simple_grasps::GraspData grasp_data_;
 
     // which arm are we using
-    std::string side_;
+    std::string end_effector_name_;
     std::string planning_group_name_;
 
   public:
 
     // Constructor
-    GraspGeneratorServer(const std::string &name, const std::string &side)
+    GraspGeneratorServer(const std::string &name)
       : nh_("~")
       , as_(nh_, name, boost::bind(&moveit_simple_grasps::GraspGeneratorServer::executeCB, this, _1), false)
-      , side_(side)
-      , planning_group_name_(side_+"_arm")
+      , end_effector_name_("end_effector")
+      , planning_group_name_("arm")
     {
       // ---------------------------------------------------------------------------------------------
+      nh_.param("group", planning_group_name_, planning_group_name_);
+      nh_.param("end_effector", end_effector_name_, end_effector_name_);
+
       // Load grasp data specific to our robot
-      if (!grasp_data_.loadRobotGraspData(nh_, side_))
+      if (!grasp_data_.loadRobotGraspData(nh_, end_effector_name_))
         ros::shutdown();
 
       // ---------------------------------------------------------------------------------------------
@@ -192,7 +195,10 @@ namespace moveit_simple_grasps
 int main(int argc, char *argv[])
 {
   ros::init(argc, argv, "grasp_generator_server");
-  moveit_simple_grasps::GraspGeneratorServer grasp_generator_server("generate", "right");
+
+  moveit_simple_grasps::GraspGeneratorServer grasp_generator_server("generate");
+
   ros::spin();
+
   return 0;
 }


### PR DESCRIPTION
Add `group` and `end_effector` params to the `grasp_generator_server`.

This allows to use it with other robots, not only the REEM or any robot with the hard-coded end effector and planning group names on the current implementation.
