### PR TITLE
Fix to support ROS kinetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(moveit_simple_grasps)
 
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++11")
+
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   roscpp

--- a/include/moveit_simple_grasps/custom_environment2.h
+++ b/include/moveit_simple_grasps/custom_environment2.h
@@ -74,15 +74,15 @@ void createEnvironment(moveit_visual_tools::MoveItVisualToolsPtr visual_tools_)
   // --------------------------------------------------------------------------------------------
   // Add objects to scene
 
-  // Walls                          x,     y,     angle,  width, name
-  visual_tools_->publishCollisionWall(-0.55, 0,     0,      2.2,   WALL1_NAME);  // back wall
-  visual_tools_->publishCollisionWall(0.05,  -1.1,  M_PI/2, 2.0,   WALL2_NAME);  // baxter's right
-  visual_tools_->publishCollisionWall(0.05,  1.1,   M_PI/2, 2.0,   WALL3_NAME);  // baxter's left
+  // Walls                            x,     y,     angle,  width, height, name
+  visual_tools_->publishCollisionWall(-0.55, 0,     0,      2.2,   1.5,    WALL1_NAME);  // back wall
+  visual_tools_->publishCollisionWall(0.05,  -1.1,  M_PI/2, 2.0,   1.5,    WALL2_NAME);  // baxter's right
+  visual_tools_->publishCollisionWall(0.05,  1.1,   M_PI/2, 2.0,   1.5,    WALL3_NAME);  // baxter's left
 
-  // Tables                          x,       y,       angle, width,       height,       depth,       name
-  visual_tools_->publishCollisionTable(0.78,    -0.8,    0,     0.4,         1.4,          0.47,        SUPPORT_SURFACE1_NAME); // computer monitor
-  visual_tools_->publishCollisionTable(0.78,    -0.45,   0,     0.4,         0.7,          0.47,        SUPPORT_SURFACE2_NAME); // my desk
-  visual_tools_->publishCollisionTable(TABLE_X, TABLE_Y, 0,     TABLE_WIDTH, TABLE_HEIGHT, TABLE_DEPTH, SUPPORT_SURFACE3_NAME); // andy table
+  // Tables                            x,       y,       z, angle, width,       height,       depth,       name
+  visual_tools_->publishCollisionTable(0.78,    -0.8,    0, 0,     0.4,         1.4,          0.47,        SUPPORT_SURFACE1_NAME); // computer monitor
+  visual_tools_->publishCollisionTable(0.78,    -0.45,   0, 0,     0.4,         0.7,          0.47,        SUPPORT_SURFACE2_NAME); // my desk
+  visual_tools_->publishCollisionTable(TABLE_X, TABLE_Y, 0, 0,     TABLE_WIDTH, TABLE_HEIGHT, TABLE_DEPTH, SUPPORT_SURFACE3_NAME); // andy table
 }
 
 double getTableHeight(double floor_offset)

--- a/include/moveit_simple_grasps/moveit_blocks.h
+++ b/include/moveit_simple_grasps/moveit_blocks.h
@@ -186,7 +186,7 @@ public:
             ROS_INFO_STREAM_NAMED("pick_place","Picking '" << blocks[block_id].name << "'");
 
             // Visualize the block we are about to pick
-            visual_tools_->publishBlock( blocks[block_id].start_pose, rviz_visual_tools::BLUE, BLOCK_SIZE);
+            visual_tools_->publishCuboid(blocks[block_id].start_pose, BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE, rviz_visual_tools::BLUE);
 
             if( !pick(blocks[block_id].start_pose, blocks[block_id].name) )
             {
@@ -212,7 +212,7 @@ public:
             ROS_INFO_STREAM_NAMED("pick_place","Placing '" << blocks[block_id].name << "'");
 
             // Publish goal block location
-            visual_tools_->publishBlock( blocks[block_id].goal_pose, rviz_visual_tools::BLUE, BLOCK_SIZE);
+            visual_tools_->publishCuboid(blocks[block_id].goal_pose, BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE, rviz_visual_tools::BLUE);
 
             if( !place(blocks[block_id].goal_pose, blocks[block_id].name) )
             {
@@ -363,7 +363,7 @@ public:
 
       place_loc.place_pose = pose_stamped;
 
-      visual_tools_->publishBlock( place_loc.place_pose.pose, rviz_visual_tools::BLUE, BLOCK_SIZE);
+      visual_tools_->publishCuboid(place_loc.place_pose.pose, BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE, rviz_visual_tools::BLUE);
 
       // Approach
       moveit_msgs::GripperTranslation pre_place_approach;

--- a/src/grasp_filter_test.cpp
+++ b/src/grasp_filter_test.cpp
@@ -130,16 +130,18 @@ public:
 
     // ---------------------------------------------------------------------------------------------
     // Load the Robot Viz Tools for publishing to Rviz
+    const robot_model::JointModelGroup* ee_jmg = planning_scene_monitor_->getRobotModel()->getJointModelGroup(grasp_data_.ee_group_);
+
     visual_tools_.reset(new moveit_visual_tools::MoveItVisualTools(grasp_data_.base_link_, "/end_effector_marker", planning_scene_monitor_));
     visual_tools_->setLifetime(40.0);
-    visual_tools_->loadEEMarker(grasp_data_.ee_group_);
+    visual_tools_->loadEEMarker(ee_jmg);
     visual_tools_->setFloorToBaseHeight(-0.9);
 
     // Clear out old collision objects just because
     //visual_tools_->removeAllCollisionObjects();
 
     // Create a collision table for fun
-    visual_tools_->publishCollisionTable(TABLE_X, TABLE_Y, 0, TABLE_WIDTH, TABLE_HEIGHT, TABLE_DEPTH, "table");
+    visual_tools_->publishCollisionTable(TABLE_X, TABLE_Y, 0, 0, TABLE_WIDTH, TABLE_HEIGHT, TABLE_DEPTH, "table");
 
     // ---------------------------------------------------------------------------------------------
     // Load grasp generator
@@ -168,7 +170,7 @@ public:
         generateRandomObject(object_pose);
 
       // Show the block
-      visual_tools_->publishBlock(object_pose, rviz_visual_tools::BLUE, BLOCK_SIZE);
+      visual_tools_->publishCuboid(object_pose, BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE, rviz_visual_tools::BLUE);
 
       possible_grasps.clear();
       ik_solutions.clear();
@@ -181,7 +183,6 @@ public:
       grasp_filter_->filterGrasps(possible_grasps, ik_solutions, filter_pregrasps, grasp_data_.ee_parent_link_, planning_group_name_);
 
       // Visualize them
-      const robot_model::JointModelGroup* ee_jmg = planning_scene_monitor_->getRobotModel()->getJointModelGroup(grasp_data_.ee_group_);
       visual_tools_->publishAnimatedGrasps(possible_grasps, ee_jmg);
       const robot_model::JointModelGroup* arm_jmg = planning_scene_monitor_->getRobotModel()->getJointModelGroup(planning_group_name_);
       visual_tools_->publishIKSolutions(ik_solutions, arm_jmg, 0.25);

--- a/src/simple_grasps_server.cpp
+++ b/src/simple_grasps_server.cpp
@@ -146,7 +146,8 @@ namespace moveit_simple_grasps
       // Load the Robot Viz Tools for publishing to Rviz
       visual_tools_.reset(new moveit_visual_tools::MoveItVisualTools(grasp_data_.base_link_));
       visual_tools_->setLifetime(120.0);
-      visual_tools_->loadEEMarker(grasp_data_.ee_group_);
+      const robot_model::JointModelGroup* ee_jmg = visual_tools_->getRobotModel()->getJointModelGroup(grasp_data_.ee_group_);
+      visual_tools_->loadEEMarker(ee_jmg);
 
       // ---------------------------------------------------------------------------------------------
       // Load grasp generator

--- a/src/simple_grasps_test.cpp
+++ b/src/simple_grasps_test.cpp
@@ -112,14 +112,14 @@ public:
     {
       // Test visualization of end effector in OPEN position
       grasp_data_.setRobotStatePreGrasp( visual_tools_->getSharedRobotState() );
-      visual_tools_->loadEEMarker(grasp_data_.ee_group_);
       const robot_model::JointModelGroup* ee_jmg = visual_tools_->getRobotModel()->getJointModelGroup(grasp_data_.ee_group_);
+      visual_tools_->loadEEMarker(ee_jmg);
       visual_tools_->publishEEMarkers(pose, ee_jmg, rviz_visual_tools::ORANGE, "test_eef");
       ros::Duration(1.0).sleep();
 
       // Test visualization of end effector in CLOSED position
       grasp_data_.setRobotStateGrasp( visual_tools_->getSharedRobotState() );
-      visual_tools_->loadEEMarker(grasp_data_.ee_group_);
+      visual_tools_->loadEEMarker(ee_jmg);
       visual_tools_->publishEEMarkers(pose, ee_jmg, rviz_visual_tools::GREEN, "test_eef");
       ros::Duration(1.0).sleep();
     }
@@ -142,12 +142,12 @@ public:
         generateRandomObject(object_pose);
 
       // Show the block
-      visual_tools_->publishBlock(object_pose, rviz_visual_tools::BLUE, BLOCK_SIZE);
+      visual_tools_->publishCuboid(object_pose, BLOCK_SIZE, BLOCK_SIZE, BLOCK_SIZE, rviz_visual_tools::BLUE);
 
       possible_grasps.clear();
 
       // Generate set of grasps for one object
-      simple_grasps_->generateBlockGrasps( object_pose, grasp_data_, possible_grasps);
+      simple_grasps_->generateBlockGrasps(object_pose, grasp_data_, possible_grasps);
 
       // Visualize them
       const robot_model::JointModelGroup* ee_jmg = visual_tools_->getRobotModel()->getJointModelGroup(grasp_data_.ee_group_);


### PR DESCRIPTION
@davetcoleman , this PR shows the changes to make this package `catkin build` successfully under ROS kinetic, with Ubuntu Xenial using the ROS packages currently in the `main` repositories pool, ie. `class_loader` version is 0.3.5 (it should also work with 0.3.6, which is still in `testing`).

If you create a `kinetic-devel` branch upstream, I'd make this PR against it instead of `indigo-devel`, but this way you can see the changes (which are sort of minimal) now.

FYI @anilm3
